### PR TITLE
IZPACK-1620: Override summary panel next button text

### DIFF
--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/bra.xml
@@ -252,6 +252,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Pronto para instalar. Os dados importantes são listados abaixo. Clique &quot;Próximo&quot; para iniciar a instalação, "/>
+    <str id="SummaryPanel.next" txt="Próximo"/>
     <str id="TargetPanel.summaryCaption" txt="Caminho da instalação"/>
     <str id="JDKPathPanel.summaryCaption" txt="Caminho do JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Pacotes de instalação escolhidos"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ces.xml
@@ -168,6 +168,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Instalace bude nyní probíhat podle následujících voleb. Stiskni tlačítko Další na pokráčování."/>
+    <str id="SummaryPanel.next" txt="Další"/>
     <str id="TargetPanel.summaryCaption" txt="Instalační adresář"/>
     <str id="JDKPathPanel.summaryCaption" txt="Cesta k JDK"/>
     <str id="InstallationGroupPanel.summaryCaption" txt="Instalační prvky"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/deu.xml
@@ -289,7 +289,7 @@ file we looked for -->
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Alle für die Installation notwendigen Daten liegen nun vor. Die wichtigsten sind nachfolgend aufgeführt. Klicken Sie auf &quot;Weiter&quot;, um mit der Installation zu beginnen. "/>
-
+    <str id="SummaryPanel.next" txt="Weiter"/>
     <str id="TargetPanel.summaryCaption" txt="Installationspfad"/>
     <str id="JDKPathPanel.summaryCaption" txt="Pfad des JDK-Verzeichnisses"/>
     <str id="PacksPanel.summaryCaption" txt="Gewählte Installationspakete"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ell.xml
@@ -190,6 +190,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Έτοιμοι για εγκατάσταση. Διάφορες σημαντικές πληροφορίες φαίνονται παρακάτω. Πατήστε «Επόμενο» για να ξεκινήσει η εγκατάσταση, "/>
+    <str id="SummaryPanel.next" txt="Επόμενο"/>
     <str id="TargetPanel.summaryCaption" txt="Κατάλογος εγκατάστασης"/>
     <str id="JDKPathPanel.summaryCaption" txt="Κατάλογος JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Επιλεγμένα πακέτα εγκατάστασης"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eng.xml
@@ -311,6 +311,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Installation will proceed with the following settings. Press Next to continue."/>
+    <str id="SummaryPanel.next" txt="Next"/>
     <str id="TargetPanel.summaryCaption" txt="Installation Path"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK Path"/>
     <str id="InstallationGroupPanel.summaryCaption" txt="Chosen Installation Feature"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/eus.xml
@@ -291,6 +291,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Instalazioa hurrengoko konfigurazioarekin hasiko da. Sakatu Aurrera jarraitzeko."/>
+    <str id="SummaryPanel.next" txt="Aurrera"/>
     <str id="TargetPanel.summaryCaption" txt="Instalazio bidea"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK bidea"/>
     <str id="PacksPanel.summaryCaption" txt="Aukeratutako instalazio paketeak"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fa.xml
@@ -247,6 +247,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="آمادۀ نصب... فهرست اطلاعات مهم در زیر آمده. برای آغاز عملیات نصب دکمۀ &quot;Next&quot; را بزنید."/>
+    <str id="SummaryPanel.next" txt="بعدی"/>
     <str id="TargetPanel.summaryCaption" txt="مسیر نصب"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK مسیر"/>
     <str id="PacksPanel.summaryCaption" txt="بسته های نصب انتخاب شده"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fin.xml
@@ -291,6 +291,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Valmis asennukseen. Tärkeät tiedot on listattu alla. Paina &quot;Seuraava&quot; aloittaaksesi asennuksen."/>
+    <str id="SummaryPanel.next" txt="Seuraava"/>
     <str id="TargetPanel.summaryCaption" txt="Asennuspolku"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK polku"/>
     <str id="PacksPanel.summaryCaption" txt="Valitut asennuspaketit"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/fra.xml
@@ -263,6 +263,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Prêt à installer. Les données importantes sont listées ci-dessous. Appuyez sur &quot;Suivant&quot; pour commencer l'installation, "/>
+    <str id="SummaryPanel.next" txt="Suivant"/>
     <str id="TargetPanel.summaryCaption" txt="Chemin de l'installation"/>
     <str id="JDKPathPanel.summaryCaption" txt="Chemin du JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Paquet(s) d'installation choisis"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/glg.xml
@@ -288,6 +288,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="A instalación procederá coas seguintes preseleccións. Presiona en Seguinte para comeza-la instalación, "/>
+    <str id="SummaryPanel.next" txt="Seguinte"/>
     <str id="TargetPanel.summaryCaption" txt="Ruta de Instalación"/>
     <str id="JDKPathPanel.summaryCaption" txt="Ruta do JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Paquetes de instalación escollidos"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/hun.xml
@@ -187,6 +187,7 @@
 
     <str id="SummaryPanel.info"
          txt="Készen állunk a telepítésre. A fontosabb beállítások listája. Kattintson az 'Következõ' gombra a telepítés megkezdéséhez, "/>
+    <str id="SummaryPanel.next" txt="Következõ"/>
     <str id="TargetPanel.summaryCaption" txt="Célmappa"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK elérési út"/>
     <str id="PacksPanel.summaryCaption" txt="Kiválasztott telepítési csomagok"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/idn.xml
@@ -280,6 +280,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Siap untuk pemasangan. Daftar data yang penting terdapat di bawah. Tekan &quot;Berikut&quot; untuk memulai pemasangan."/>
+    <str id="SummaryPanel.next" txt="Berikut"/>
     <str id="TargetPanel.summaryCaption" txt="Lokasi pemasangan"/>
     <str id="JDKPathPanel.summaryCaption" txt="Lokasi JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Paket-paket pemasangan yang dipilih"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ita.xml
@@ -275,6 +275,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="L'installazione proseguirà con le impostazioni indicate qui sotto. Selezionare &quot;Avanti&quot; per iniziare l'installazione."/>
+    <str id="SummaryPanel.next" txt="Avanti"/>
     <str id="TargetPanel.summaryCaption" txt="Percorso installazione"/>
     <str id="JDKPathPanel.summaryCaption" txt="Percorso JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Componenti selezionati per l'installazione"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/jpn.xml
@@ -300,6 +300,7 @@
 
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info" txt="次の設定でインストールします。よければ次へボタンを押してください。"/>
+    <str id="SummaryPanel.next" txt="次へ"/>
     <str id="TargetPanel.summaryCaption" txt="インストールパス"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK パス"/>
     <str id="PacksPanel.summaryCaption" txt="選択したインストール項目"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/kor.xml
@@ -206,6 +206,7 @@
 
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info" txt="설치 준비 완료. 중요한 데이터가 다음에 나와 있습니다. 설치를 시작하려면 &quot;다음&quot;을 누르십시오, "/>
+    <str id="SummaryPanel.next" txt="다음"/>
     <str id="TargetPanel.summaryCaption" txt="설치 경로"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK 경로"/>
     <str id="PacksPanel.summaryCaption" txt="선택한 설치 꾸러미"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nld.xml
@@ -331,6 +331,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Gereed voor installatie. Belangrijke gegevens staan hieronder opgesomd. Druk op &quot;Volgende&quot; om de installatie te starten."/>
+    <str id="SummaryPanel.next" txt="Volgende"/>
     <str id="TargetPanel.summaryCaption" txt="Installatie pad"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK pad"/>
     <str id="PacksPanel.summaryCaption"

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/nor.xml
@@ -316,7 +316,7 @@ file we looked for -->
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="Installasjonen vil fortsette med følgende innstillinger. Trykk på Neste for å fortsette."/>
-
+    <str id="SummaryPanel.next" txt="Neste"/>
     <str id="TargetPanel.summaryCaption" txt="Installasjonsmål"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK-filsti"/>
     <str id="PacksPanel.summaryCaption" txt="Valgte installasjonspakker"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/pol.xml
@@ -239,6 +239,7 @@
     <str id="SimpleFinishPanel.headline" txt="Instalacja zakończona"/>
     <str id="SummaryPanel.headline" txt="Podsumowanie konfiguracji"/>
     <str id="SummaryPanel.info" txt="Instalator zastosuje wybrane ustawienia. Wybierz 'Dalej' aby kontynuować."/>
+    <str id="SummaryPanel.next" txt="Dalej"/>
     <str id="TargetPanel.browse" txt="Przeglądaj..."/>
     <str id="TargetPanel.createdir" txt="Katalog docelowy zostanie utworzony: "/>
     <str id="TargetPanel.empty_target"

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/prt.xml
@@ -284,6 +284,7 @@
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info"
          txt="A Instala��o vai continuar com as configurações seguintes. Clique em Seguinte para continuar."/>
+    <str id="SummaryPanel.next" txt="Seguinte"/>
     <str id="TargetPanel.summaryCaption" txt="Localização da Instalação"/>
     <str id="JDKPathPanel.summaryCaption" txt="Localização do JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Pacotes de Instalação Escolhidos"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/rus.xml
@@ -209,6 +209,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Все необходимые данные для начала установки собраны. Нажмите &quot;Далее&quot; для запуска."/>
+    <str id="SummaryPanel.next" txt="Далее"/>
     <str id="TargetPanel.summaryCaption" txt="Каталог установки"/>
     <str id="JDKPathPanel.summaryCaption" txt="Путь к JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Выбранные модули для установки"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/slk.xml
@@ -298,6 +298,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Inštalácia je pripravená. Dôležité informácie sú v zozname dole. Pre spustenie inštalácie  stlačte &quot;Ďaľší&quot; , "/>
+    <str id="SummaryPanel.next" txt="Ďalší"/>
     <str id="TargetPanel.summaryCaption" txt="Inštalačný priečinok"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK priečinok"/>
     <str id="PacksPanel.summaryCaption" txt="Vybrané inštalačné balíky"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/spa.xml
@@ -312,6 +312,7 @@
     <!-- SummaryPanel strings -->
   <str id="SummaryPanel.info"
     txt="La configuración de la instalación ha terminado. Se muestra a continuación un resumen de la misma. Pulse &quot;Siguiente&quot; para comenzar la instalación: " />
+  <str id="SummaryPanel.next" txt="Siguiente"/>
   <str id="TargetPanel.summaryCaption" txt="Ruta de la instalación" />
   <str id="JDKPathPanel.summaryCaption" txt="Ruta del JDK" />
   <str id="InstallationGroupPanel.summaryCaption" txt="Opciones de Instalación Seleccionadas"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/swe.xml
@@ -240,6 +240,7 @@
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info"
          txt="Färdig att installera. Viktiga inställningar anges nedan. Tryck &quot;Nästa&quot; för att starta installationen, "/>
+    <str id="SummaryPanel.next" txt="Nästa"/>
     <str id="TargetPanel.summaryCaption" txt="Sökväg för installationen"/>
     <str id="JDKPathPanel.summaryCaption" txt="Sökväg till JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Valda paket för installering"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/twn.xml
@@ -194,6 +194,7 @@
 
     <!-- Strings for the summary of panels - START -->
     <str id="SummaryPanel.info" txt="安裝程式會執行下面設定，請按下一步繼續。"/>
+    <str id="SummaryPanel.next" txt="下一步"/>
     <str id="TargetPanel.summaryCaption" txt="安裝路徑"/>
     <str id="JDKPathPanel.summaryCaption" txt="JDK 路徑"/>
     <str id="PacksPanel.summaryCaption" txt="選擇安裝的套件"/>

--- a/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
+++ b/izpack-core/src/main/resources/com/izforge/izpack/bin/langpacks/installer/ukr.xml
@@ -280,6 +280,7 @@
 
     <!-- SummaryPanel strings -->
     <str id="SummaryPanel.info" txt="Встановлення пройде з такими налашутваннями. Натисніть Далі."/>
+    <str id="SummaryPanel.next" txt="Далі"/>
     <str id="TargetPanel.summaryCaption" txt="Шлях встановлення"/>
     <str id="JDKPathPanel.summaryCaption" txt="Шлях до JDK"/>
     <str id="PacksPanel.summaryCaption" txt="Вказані пакунки до встановлення"/>

--- a/izpack-panel/src/main/java/com/izforge/izpack/panels/summary/SummaryPanel.java
+++ b/izpack-panel/src/main/java/com/izforge/izpack/panels/summary/SummaryPanel.java
@@ -90,8 +90,19 @@ public class SummaryPanel extends IzPanel
     public void panelActivate()
     {
         super.panelActivate();
+        String nextText = getString("SummaryPanel.next");
+        if (nextText == null)
+        {
+            nextText = getString("installer.next");
+        }
+        parent.getNavigator().setNextText(nextText);
         textArea.setText(SummaryProcessor.getSummary(this.installData));
         textArea.setCaretPosition(0);
     }
 
+    public void panelDeactivate()
+    {
+        super.panelDeactivate();
+        parent.getNavigator().setNextText(getString("installer.next"));
+    }
 }


### PR DESCRIPTION
Added the ability to override the Next navigation button text for the SummaryPanel via lang .xml files. Key = SummaryPanel.next

Ex:     `<str id="SummaryPanel.next" txt="Next"/>`